### PR TITLE
Add HTML line breaks to description

### DIFF
--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -1,7 +1,7 @@
 <?php include("_header.phtml") ?>
 <div class="media">
   <div class="media-left">
-    <img class="media-object" src="<?php echo htmlspecialchars($data['icon_url']) ?>" alt="<?php echo htmlspecialchars($data['title']) ?>'s icon" width=80 height=80>
+    <img class="media-object" src="<?php echo htmlspecialchars($data['icon_url']) ?>" alt="<?php echo htmlspecialchars($data['title']) ?>'s icon" width="80" height="80">
   </div>
   <div class="media-body">
     <h4 class="media-heading">

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -20,7 +20,7 @@
 
     <p class="text-muted">Submitted by user <?php echo htmlspecialchars($data['author']) ?>; <?php echo htmlspecialchars($data['cost']) ?></p>
     <p>
-      <?php echo $data['description'] ?>
+      <?php echo nl2br(htmlspecialchars($data['description']), false) ?>
     </p>
     <hr/>
     <p>


### PR DESCRIPTION
This adds `<br>` tags in the description, so line breaks are shown in the browser. I also added escaping while at it and quotes to two lonely attributes at the icon `<img>` to make them consistent with the rest.

Fixes #13.