### PR TITLE
Strip potential trailing slash in repo URL

### DIFF
--- a/src/helpers/utils.php
+++ b/src/helpers/utils.php
@@ -18,30 +18,30 @@ class Utils
     $light_warning_suffix = "Please, doublecheck that the URL and the repository provider are correct.";
     switch ($provider) {
       case 'GitHub':
-        if(sizeof(preg_grep('/^https:\/\/github\.com\/.+?\/.+?$/', [$repo_url])) == 0) {
+        if(sizeof(preg_grep('/^https:\/\/github\.com\/[^\/]+?\/[^\/]+?$/', [$repo_url])) == 0) {
           $warning = "\"$repo_url\" doesn't look correct; it should be similar to \"https://github.com/<owner>/<name>\". $warning_suffix";
         }
         return "$repo_url/archive/$commit.zip";
       case 'GitLab':
-        if(sizeof(preg_grep('/^https:\/\/(gitlab\.com|[^\/]+)\/.+?\/.+?$/', [$repo_url])) == 0) {
+        if(sizeof(preg_grep('/^https:\/\/(gitlab\.com|[^\/]+)\/[^\/]+?\/[^\/]+?$/', [$repo_url])) == 0) {
           $warning = "\"$repo_url\" doesn't look correct; it should be similar to \"https://<gitlab instance>/<owner>/<name>\". $warning_suffix";
-        } elseif(sizeof(preg_grep('/^https:\/\/(gitlab\.com)\/.+?\/.+?$/', [$repo_url])) == 0) {
+        } elseif(sizeof(preg_grep('/^https:\/\/(gitlab\.com)\/[^\/]+?\/[^\/]+?$/', [$repo_url])) == 0) {
           $warning = "\"$repo_url\" might not be correct; it should be similar to \"https://gitlab.com/<owner>/<name>\", unless the asset is hosted on a custom instance of GitLab. $light_warning_suffix";
         }
         return "$repo_url/repository/archive.zip?ref=$commit";
       case 'BitBucket':
-        if(sizeof(preg_grep('/^https:\/\/bitbucket\.org\/.+?\/.+?$/', [$repo_url])) == 0) {
+        if(sizeof(preg_grep('/^https:\/\/bitbucket\.org\/[^\/]+?\/[^\/]+?$/', [$repo_url])) == 0) {
           $warning = "\"$repo_url\" doesn't look correct; it should be similar to \"https://bitbucket.org/<owner>/<name>\". $warning_suffix";
         }
         return "$repo_url/get/$commit.zip";
       case 'Gogs':
-        if(sizeof(preg_grep('/^https?:\/\/.+?\/.+?\/.+?$/', [$repo_url])) == 0) {
+        if(sizeof(preg_grep('/^https?:\/\/[^\/]+?\/[^\/]+?\/[^\/]+?$/', [$repo_url])) == 0) {
           $warning = "\"$repo_url\" doesn't look correct; it should be similar to \"http<s>://<gogs instance>/<owner>/<name>\". $warning_suffix";
         }
         $warning = "Since Gogs might be self-hosted, we can't be sure that \"$repo_url\" is a valid Gogs URL. $light_warning_suffix";
         return "$repo_url/archive/$commit.zip";
       case 'cgit':
-        if(sizeof(preg_grep('/^https?:\/\/.+?\/.+?\/.+?$/', [$repo_url])) == 0) {
+        if(sizeof(preg_grep('/^https?:\/\/[^\/]+?\/[^\/]+?\/[^\/]+?$/', [$repo_url])) == 0) {
           $warning = "\"$repo_url\" doesn't look correct; it should be similar to \"http<s>://<cgit instance>/<owner>/<name>\". $warning_suffix";
         }
         $warning = "Since cgit might be self-hosted, we can't be sure that \"$repo_url\" is a valid cgit URL. $light_warning_suffix";

--- a/src/helpers/utils.php
+++ b/src/helpers/utils.php
@@ -10,6 +10,7 @@ class Utils
 
   public function get_computed_download_url($repo_url, $provider, $commit, &$warning=null) // i.e. browse_url, download_provider, download_commit
   {
+    $repo_url = rtrim($repo_url, '/');
     if(is_int($provider)) {
       $provider = $this->c->constants['download_provider'][$provider];
     }

--- a/templates/_asset_fields.phtml
+++ b/templates/_asset_fields.phtml
@@ -61,7 +61,7 @@ $_asset_values = array_merge([
 		<label class="col-md-4 control-label" for="browse">Repository URL</label>
 		<div class="col-md-5">
 				<input id="browse" name="browse_url" type="text" placeholder="Repository URL" class="form-control input-md" required="" value="<?php echo esc($_asset_values['browse_url']) ?>">
-				<span class="help-block">Set the url to browse the asset's files (webpage). Should be similar to <code>https://github.com/&lt;user&gt;/&lt;project&gt;/</code> (Might be different depending on your "provider")</span>
+				<span class="help-block">Set the url to browse the asset's files (webpage). Should be similar to <code>https://github.com/&lt;user&gt;/&lt;project&gt;</code> (Might be different depending on your "provider")</span>
 		</div>
 </div>
 


### PR DESCRIPTION
Somewhat fixes #72

However this only strips slashes at the end, so things like `https://github.com/merumelu///////////hi` are still possible (But who does this?). To fix that it might be a good idea to look up what characters are acutally valid for username/repos for each provider and replace the `.+?` in the regex accordingly.

After playing around a little on github.com/join, username rules for GitHub are like this:
* Alphanumeric only
* One hyphen
* Hyphen can't be at start or end of the name
* Maximum of 39 characters
