### PR TITLE
Better asset descriptions: Clickable username+license for filtering, add modify_date

### DIFF
--- a/src/queries.php
+++ b/src/queries.php
@@ -22,7 +22,7 @@ return [
         'list' => 'SELECT category_id as id, category as name, category_type as type FROM `as_categories` WHERE category_type LIKE :category_type ORDER BY category_id',
     ],
     'asset' => [
-        'search' => 'SELECT asset_id, title, username as author, user_id as author_id, category, category_id, godot_version, rating, cost, support_level, icon_url, version, version_string FROM `as_assets`
+        'search' => 'SELECT asset_id, title, username as author, user_id as author_id, category, category_id, godot_version, rating, cost, support_level, icon_url, version, version_string, modify_date FROM `as_assets`
             LEFT JOIN `as_users` USING (user_id)
             LEFT JOIN `as_categories` USING (category_id)
 
@@ -69,7 +69,7 @@ return [
                 OR username LIKE :filter
             )',
 
-        'get_one' => 'SELECT asset_id, category_type, title, username as author, user_id as author_id, version, version_string, category, category_id, godot_version, rating, cost, description, support_level, download_provider, download_commit, download_hash, browse_url, issues_url, icon_url, preview_id, `as_asset_previews`.type, link, thumbnail, searchable FROM `as_assets`
+        'get_one' => 'SELECT asset_id, category_type, title, username as author, user_id as author_id, version, version_string, category, category_id, godot_version, rating, cost, description, support_level, download_provider, download_commit, download_hash, browse_url, issues_url, icon_url, preview_id, `as_asset_previews`.type, link, thumbnail, searchable, modify_date FROM `as_assets`
             LEFT JOIN `as_categories` USING (category_id)
             LEFT JOIN `as_users` USING (user_id)
             LEFT JOIN `as_asset_previews` USING (asset_id)

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -30,7 +30,7 @@
         <p class="text-muted">
           Submitted by user <a href="<?php echo raw($basepath) ?>/asset?user=<?php echo esc($data['author']) ?>" title="Search assets by '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
           <a href="<?php echo raw($basepath) ?>/asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>;
-          <?php echo esc(explode(" ", $asset['modify_date'])[0]) ?>
+          <?php echo esc(explode(" ", $data['modify_date'])[0]) ?>
         </p>
         <p>
             <?php echo nl2br(esc($data['description']), false) ?>

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -27,7 +27,10 @@
             ][$data['support_level']]) ?>"><?php echo esc(ucfirst($data['support_level'])) ?></span>
         </h4>
 
-        <p class="text-muted">Submitted by user <?php echo esc($data['author']) ?>; <?php echo esc($data['cost']) ?></p>
+        <p class="text-muted">
+          Submitted by user <a href="../asset?filter=<?php echo esc($data['author']) ?>" title="Search assets with filter '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
+          <a href="../asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>
+        </p>
         <p>
             <?php echo nl2br(esc($data['description']), false) ?>
         </p>

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -28,8 +28,8 @@
         </h4>
 
         <p class="text-muted">
-          Submitted by user <a href="../asset?filter=<?php echo esc($data['author']) ?>" title="Search assets with filter '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
-          <a href="../asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>;
+          Submitted by user <a href="<?php echo raw($basepath) ?>/asset?filter=<?php echo esc($data['author']) ?>" title="Search assets with filter '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
+          <a href="<?php echo raw($basepath) ?>/asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>;
           <?php echo esc(explode(" ", $asset['modify_date'])[0]) ?>
         </p>
         <p>

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -28,7 +28,7 @@
         </h4>
 
         <p class="text-muted">
-          Submitted by user <a href="<?php echo raw($basepath) ?>/asset?filter=<?php echo esc($data['author']) ?>" title="Search assets with filter '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
+          Submitted by user <a href="<?php echo raw($basepath) ?>/asset?user=<?php echo esc($data['author']) ?>" title="Search assets by '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
           <a href="<?php echo raw($basepath) ?>/asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>;
           <?php echo esc(explode(" ", $asset['modify_date'])[0]) ?>
         </p>

--- a/templates/asset.phtml
+++ b/templates/asset.phtml
@@ -29,7 +29,8 @@
 
         <p class="text-muted">
           Submitted by user <a href="../asset?filter=<?php echo esc($data['author']) ?>" title="Search assets with filter '<?php echo esc($data['author']) ?>'"><?php echo esc($data['author']) ?></a>;
-          <a href="../asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>
+          <a href="../asset?filter=<?php echo esc($data['cost']) ?>" title="Search assets with filter '<?php echo esc($data['cost']) ?>'"><?php echo esc($data['cost']) ?></a>;
+          <?php echo esc(explode(" ", $asset['modify_date'])[0]) ?>
         </p>
         <p>
             <?php echo nl2br(esc($data['description']), false) ?>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -102,7 +102,8 @@
 
                     <p class="text-muted">
                       Submitted by user <a href="?filter=<?php echo esc($asset['author']) ?>" title="Search assets with filter '<?php echo esc($asset['author']) ?>'"><?php echo esc($asset['author']) ?></a>;
-                      <a href="?filter=<?php echo esc($asset['cost']) ?>" title="Search assets with filter '<?php echo esc($asset['cost']) ?>'"><?php echo esc($asset['cost']) ?></a>
+                      <a href="?filter=<?php echo esc($asset['cost']) ?>" title="Search assets with filter '<?php echo esc($asset['cost']) ?>'"><?php echo esc($asset['cost']) ?></a>;
+                      <?php echo esc(explode(" ", $asset['modify_date'])[0]) ?>
                     </p>
                 </div>
             </div>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -101,7 +101,7 @@
                     </h4>
 
                     <p class="text-muted">
-                      Submitted by user <a href="?filter=<?php echo esc($asset['author']) ?>" title="Search assets with filter '<?php echo esc($asset['author']) ?>'"><?php echo esc($asset['author']) ?></a>;
+                      Submitted by user <a href="?user=<?php echo esc($asset['author']) ?>" title="Search assets by '<?php echo esc($asset['author']) ?>'"><?php echo esc($asset['author']) ?></a>;
                       <a href="?filter=<?php echo esc($asset['cost']) ?>" title="Search assets with filter '<?php echo esc($asset['cost']) ?>'"><?php echo esc($asset['cost']) ?></a>;
                       <?php echo esc(explode(" ", $asset['modify_date'])[0]) ?>
                     </p>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -101,8 +101,8 @@
                     </h4>
 
                     <p class="text-muted">
-                      Submitted by user <a href="../asset?filter=<?php echo esc($asset['author']) ?>" title="Search assets with filter '<?php echo esc($asset['author']) ?>'"><?php echo esc($asset['author']) ?></a>;
-                      <a href="../asset?filter=<?php echo esc($asset['cost']) ?>" title="Search assets with filter '<?php echo esc($asset['cost']) ?>'"><?php echo esc($asset['cost']) ?></a>
+                      Submitted by user <a href="?filter=<?php echo esc($asset['author']) ?>" title="Search assets with filter '<?php echo esc($asset['author']) ?>'"><?php echo esc($asset['author']) ?></a>;
+                      <a href="?filter=<?php echo esc($asset['cost']) ?>" title="Search assets with filter '<?php echo esc($asset['cost']) ?>'"><?php echo esc($asset['cost']) ?></a>
                     </p>
                 </div>
             </div>

--- a/templates/assets.phtml
+++ b/templates/assets.phtml
@@ -100,7 +100,10 @@
                         ][$asset['support_level']]) ?>"><?php echo esc(ucfirst($asset['support_level'])) ?></span>
                     </h4>
 
-                    <p>Submitted by user <?php echo esc($asset['author']) ?>; <?php echo esc($asset['cost']) ?></p>
+                    <p class="text-muted">
+                      Submitted by user <a href="../asset?filter=<?php echo esc($asset['author']) ?>" title="Search assets with filter '<?php echo esc($asset['author']) ?>'"><?php echo esc($asset['author']) ?></a>;
+                      <a href="../asset?filter=<?php echo esc($asset['cost']) ?>" title="Search assets with filter '<?php echo esc($asset['cost']) ?>'"><?php echo esc($asset['cost']) ?></a>
+                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
These changes improve the asset descriptions:
- make the username and license text clickable links, applying a search filter with the given user/license
- append the modify_date (date portion, without the hours and seconds)

![asset-desc](https://user-images.githubusercontent.com/1654763/30938244-ae7855ea-a3d9-11e7-9c1a-42722cead0a6.png)
