### PR TITLE
Use composer to autoload classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,5 +6,11 @@
         "monolog/monolog": "^1.17",
         "slim/php-view": "^2.0",
         "phpmailer/phpmailer": "^5.2"
+    },
+
+    "autoload": {
+        "psr-4": {
+            "Godot\\AssetLibrary\\": "src/"
+        }
     }
 }

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -97,12 +97,10 @@ $container['cookies'] = function ($c) {
 
 // tokens
 $container['tokens'] = function ($c) {
-    require_once __DIR__ . '/Helpers/Tokens.php';
     return new Godot\AssetLibrary\Helpers\Tokens($c);
 };
 
 // utils
 $container['utils'] = function ($c) {
-    require_once __DIR__ . '/Helpers/Utils.php';
     return new Godot\AssetLibrary\Helpers\Utils($c);
 };


### PR DESCRIPTION
Let composer handle the `require`'ing of the Tokens and Util classes.
If this is merged, `composer dump-autoload` needs to be run once so it regenerates the autoload file.