### PR TITLE
Remove legacy redirect when the URL starts with "frontend"

### DIFF
--- a/src/middleware.php
+++ b/src/middleware.php
@@ -33,10 +33,6 @@ if (FRONTEND) {
         $route = $request->getAttribute('route');
         $path = $request->getUri()->getPath();
 
-        if (substr($path, 0, 8) == 'frontend') {
-            $response = $response->withHeader('Location', $request->getUri()->getBasePath() . substr($path, 8) . '?' . $request->getUri()->getQuery());
-        }
-
         if (isset($static_routes['/' . $path])) {
             $queryUri = '/' . $path;
         } elseif ($route) {


### PR DESCRIPTION
No other pages link to godotengine.org/asset-library/frontend except two Google results, but only if you explicitly include the "frontend" part in your search query so I assume this is safe to remove.