### PR TITLE
Add more version options for CC licenses and clarify the versions used

### DIFF
--- a/templates/_asset_fields.phtml
+++ b/templates/_asset_fields.phtml
@@ -131,9 +131,11 @@ $_asset_values = array_merge([
                 'GPLv3' => 'GPL v3',
                 'GPLv2' => 'GPL v2',
                 'AGPLv3' => 'AGPL v3',
-                'CC0' => 'CC0',
-                'CC-BY' => 'CC-BY',
-                'CC-BY-SA' => 'CC-BY-SA',
+                'CC0' => 'CC0 1.0 Universal',
+                'CC-BY-4.0' => 'CC BY 4.0 International',
+                'CC-BY-3.0' => 'CC BY 3.0 Unported',
+                'CC-BY-SA-4.0' => 'CC BY-SA 4.0 International',
+                'CC-BY-SA-3.0' => 'CC BY-SA 3.0 Unported',
                 'BSD-2-Clause' => 'BSD 2-clause License',
                 'BSL-1.0' => 'Boost Software License'
             ] ?>


### PR DESCRIPTION
Follow-up to #152.

It's important to specify the version number because there are significant differencees between versions (as well as potential incompatibility issues).

CC license versions below 3.0 are very uncommon today (and are not considered free by the Debian Free Software Guidelines), so I did not add them to the list.