### PR TITLE
Add Zlib license

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -101,6 +101,7 @@ return $constants = [
         'BSL-1.0' => 'Boost Software License',
         'ISC' => 'ISC License',
         'Unlicense' => 'The Unlicense License',
+        'Zlib' => 'zlib License'
         'Proprietary' => 'Proprietary (see LICENSE file)',
     ]
 ];


### PR DESCRIPTION
Adds the [Zlib license](https://spdx.org/licenses/Zlib.html).

Used in both zlib and libpng, this license is both FSF and OSI approved.