### PR TITLE
a comma is missing from the license table

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -101,7 +101,7 @@ return $constants = [
         'BSL-1.0' => 'Boost Software License',
         'ISC' => 'ISC License',
         'Unlicense' => 'The Unlicense License',
-        'Zlib' => 'zlib License'
+        'Zlib' => 'zlib License',
         'Proprietary' => 'Proprietary (see LICENSE file)',
     ]
 ];


### PR DESCRIPTION
- *Maintainer edit: Follow-up to https://github.com/godotengine/godot-asset-library/pull/374.*