### PR TITLE
Add Godot 4.7 to the list of versions

### DIFF
--- a/src/constants.php
+++ b/src/constants.php
@@ -77,6 +77,7 @@ return $constants = [
         '4.4',
         '4.5',
         '4.6',
+        '4.7',
         'unknown',
         'custom_build',
     ],


### PR DESCRIPTION
Makes it possible to make an addon only target Godot 4.7+.